### PR TITLE
Merge #71 (load slides timeout) into v5.3 

### DIFF
--- a/services/loadSlides.php
+++ b/services/loadSlides.php
@@ -1,4 +1,5 @@
 <?php
+ini_set('max_execution_time', '45');
 use toolmarr\WebSlideshow\DbWebSlideshow;
 
 require_once('../vendor/autoload.php');


### PR DESCRIPTION
updated inline timeout value from default of 30 seconds to 45 seconds